### PR TITLE
Fix article typo

### DIFF
--- a/posts/en/2016-10-01-making-jekyll-multilingual.md
+++ b/posts/en/2016-10-01-making-jekyll-multilingual.md
@@ -118,7 +118,7 @@ To create a language selector, like the one at the top right of this page, the p
 ```
 {% endraw %}
 
-As you can see, we need to repeat the code for the pages (`site.page`) and the posts (`site.articles`). It will be possible to delete this redundancy when *Jekyll* will use *Liquid* 4.
+As you can see, we need to repeat the code for the pages (`site.page`) and the posts (`site.posts`). It will be possible to delete this redundancy when *Jekyll* will use *Liquid* 4.
 
 Then, in order to emphase the actual version, just use CSS[[you need to declare the `lang` attribute on the `html`, with `<html lang="{{ page.lang }}">` in the *layout*]]. For instance, if you want to bold it:
 

--- a/posts/fr/2016-10-01-rendre-jekyll-multilingue.md
+++ b/posts/fr/2016-10-01-rendre-jekyll-multilingue.md
@@ -119,7 +119,7 @@ Pour créer un sélecteur de langue, comme celui présent en haut à droite de c
 ```
 {% endraw %}
 
-Comme vous pouvez le voir, nous devons répéter le code : une fois pour les pages (`site.page`) et une fois pour les articles (`site.articles`). Il sera possible de réduire le code lorsque *Jekyll* prendra en charge *Liquid* 4.
+Comme vous pouvez le voir, nous devons répéter le code : une fois pour les pages (`site.page`) et une fois pour les articles (`site.posts`). Il sera possible de réduire le code lorsque *Jekyll* prendra en charge *Liquid* 4.
 
 Pour emphaser la langue de la version affichée, il suffit d'utiliser CSS[[pour cela, il faut bien déclarer l'attribut `lang` de la balise `html` en indiquant `<html lang="{{ page.lang }}">` dans le *layout*]]. Par exemple, pour la mettre en gras :
 


### PR DESCRIPTION
This is to fix a typo in `Making Jekyll multilingual` (October 2016) in both the English and French versions of the post.

The post says that the articles are `site.articles` when they are in fact `site.posts`.