### PR TITLE
Fix code snippet in Rendre Jekyll multilingue

### DIFF
--- a/posts/fr/2016-10-01-rendre-jekyll-multilingue.md
+++ b/posts/fr/2016-10-01-rendre-jekyll-multilingue.md
@@ -262,6 +262,8 @@ Nous utilisons alors le code suivant, que l'on place dans un fichier `date.html`
 
 {% raw %}
 ```liquid
+{{ include.date | date: "%-d" }}
+
 {% assign day = include.date | date: "%-d" %}
 {% if page.lang != 'fr' %}
     {% case day %}


### PR DESCRIPTION
 - Multilingual `date.html` include did not print the day `%-d`
 - English translation code has no error

_To be fixed:_
The code generates an unwanted space between the day number `%-d` and suffix `st`, `nd` and so on, for example: `20 th August 2018`.